### PR TITLE
Fix handling of comments and locations

### DIFF
--- a/includes/admin/class-dt-import.php
+++ b/includes/admin/class-dt-import.php
@@ -1267,6 +1267,10 @@ class DT_Import {
                     value="title" <?php selected( $field == 'title' ) ?> ><?php esc_attr( $this->post_label_singular ); ?>
                     Name
                 </option>
+                <option
+                    value="notes" <?php selected( $field == 'notes' ) ?> ><?php esc_attr( $this->post_label_singular ); ?>
+                    Notes
+                </option>
 
                 <?php
                 foreach ( $channels as $label => $item ) {

--- a/includes/admin/class-dt-import.php
+++ b/includes/admin/class-dt-import.php
@@ -1025,7 +1025,7 @@ class DT_Import {
                             // sect : modifying item
                             // removing contact_address from item to avoid address duplication
                             const modifiedItem = JSON.parse(item);
-                            const tmpLocations = modifiedItem.contact_address?.values || [];
+                            const tmpLocations = modifiedItem.contact_address?.values || modifiedItem.location_grid?.values || [];
 
                             const arrLocations = [];
 


### PR DESCRIPTION
- The `notes` field has been changed since last update of this plugin, so it no longer showed in list of fields to map to. This adds it to the standard fields
- When Mapbox was enabled on a site, the locations field maps to `location_grid`, but the script was pulling locations from `contact_address`. This adds null coalescing to check both of those fields.