### PR TITLE
IMP#35 - Warning On Import

### DIFF
--- a/includes/admin/class-dt-import.php
+++ b/includes/admin/class-dt-import.php
@@ -703,7 +703,6 @@ class DT_Import {
         $multi_separator = $this->multi_separator;
 
         //open file
-        ini_set( 'auto_detect_line_endings', true );
         $file_data = fopen( $filepath, 'r' );
 
         $data_rows = array();


### PR DESCRIPTION
- fixes: #35 
---

Removed `auto_detect_line_endings` directive; which is now deprecated; as `\r` typically found within legacy Mac OS environments. See following resource links.

- [PHP 8.1: auto_detect_line_endings INI directive is deprecated](https://php.watch/versions/8.1/auto_detect_line_endings-ini-deprecated)
- [PHP - Deprecated Features](https://www.php.net/manual/en/migration81.deprecated.php#:~:text=The%20auto_detect_line_endings%20INI%20directive%20is,r%22%20line%20breaks%20manually%20instead.)
- [auto_detect_line_endings - Are there side effects?](https://stackoverflow.com/questions/31331110/auto-detect-line-endings-are-there-side-effects)